### PR TITLE
Bypass middleware for admin site urls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 install:
 	pip install -r requirements_tests.txt
 
+report:
+	pytest --cov=global_query_strings --cov-report=html tests
+
 release_test:
 	- rm -rf build && rm -rf dist && rm -rf *.egg-info
 	- python setup.py sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Here is the list of all the settings with their default values:
 GLOBAL_QUERY_STRINGS_IGNORE_URLS = []
 GLOBAL_QUERY_STRINGS_IGNORE_RELATIVE_PATHS = False
 GLOBAL_QUERY_STRINGS_PARAMS = {}
+GLOBAL_QUERY_STRINGS_EXCLUDE_PATHS_LIST = []
 ```
 
 #### GLOBAL_QUERY_STRINGS_IGNORE_URLS 
@@ -60,6 +61,10 @@ GLOBAL_QUERY_STRINGS_PARAMS = {}
 
 #### GLOBAL_QUERY_STRINGS_PARAMS 
 `GLOBAL_QUERY_STRINGS_PARAMS` takes a dictionary of global query strings to set e.g.: `{"foo": "bar", "lorem": "ipsum"}`. The query strings found in `GLOBAL_QUERY_STRINGS_PARAMS` would be replaced / added to the urls found by the parser.
+
+#### GLOBAL_QUERY_STRINGS_EXCLUDE_PATHS_LIST
+`GLOBAL_QUERY_STRINGS_EXCLUDE_PATHS_LIST` is a list of paths to exclude that takes place in the middleware only. 
+All the paths that starts with any elements of the list will bypass the middleware. e.g.: `["/admin"]`
 
 ## Usage
 Here is an example of input / output with the following settings:

--- a/global_query_strings/middleware.py
+++ b/global_query_strings/middleware.py
@@ -1,4 +1,8 @@
+from django.conf import settings
+
 from .utils import add_query_strings_to_links
+
+EXCLUDE_PATHS_LIST = getattr(settings, "GLOBAL_QUERY_STRINGS_EXCLUDE_PATHS_LIST", [])
 
 
 class GlobalQueryStringsMiddleware:
@@ -8,9 +12,19 @@ class GlobalQueryStringsMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
 
-        if (
-            "Content-Type" in response and "text/html" in response["Content-Type"]
-        ):
+        if self._exclude_paths(request):
+            return response
+
+        if "Content-Type" in response and "text/html" in response["Content-Type"]:
             response.content = add_query_strings_to_links(response.content)
 
         return response
+
+    @staticmethod
+    def _exclude_paths(request):
+        """
+        Check if the current path match a value of the GLOBAL_QUERY_STRINGS_EXCLUDE_PATHS_LIST settings.
+
+        Returns a boolean: True if the requested path should bypass the middleware False otherwise.
+        """
+        return any(bool(request.path.startswith(path)) for path in EXCLUDE_PATHS_LIST)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="django-global-query-strings",
-    version="0.2.0",
+    version="0.3.0",
     description="Django global query strings allows adding query strings (query params) site-wide",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -15,3 +15,5 @@ DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 GLOBAL_QUERY_STRINGS_IGNORE_URLS = ["example.com", "https://www.foo.org"]
 GLOBAL_QUERY_STRINGS_IGNORE_RELATIVE_PATHS = True
 GLOBAL_QUERY_STRINGS_PARAMS = {"foo": "bar", "lorem": "ipsum"}
+
+ROOT_URLCONF = "tests.urls"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -15,5 +15,4 @@ DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 GLOBAL_QUERY_STRINGS_IGNORE_URLS = ["example.com", "https://www.foo.org"]
 GLOBAL_QUERY_STRINGS_IGNORE_RELATIVE_PATHS = True
 GLOBAL_QUERY_STRINGS_PARAMS = {"foo": "bar", "lorem": "ipsum"}
-
-ROOT_URLCONF = "tests.urls"
+GLOBAL_QUERY_STRINGS_EXCLUDE_PATHS_LIST = ["/admin"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -11,6 +11,7 @@ def dummy_middleware(request):
     response.status_code = 200
     return response
 
+
 def dummy_html_middleware(request):
     response = dummy_middleware(request)
     response["Content-type"] = "text/html"
@@ -24,7 +25,6 @@ def dummy_pdf_middleware(request):
 
 
 class TestGlobalQueryStringsMiddleware:
-
     def test_init(self):
         """Testing the __init__ method"""
         # GIVEN / WHEN
@@ -38,6 +38,7 @@ class TestGlobalQueryStringsMiddleware:
         mock_add_query_strings_to_links = mocker.patch(
             "global_query_strings.middleware.add_query_strings_to_links"
         )
+        request.path = "/"
         middleware = GlobalQueryStringsMiddleware(dummy_html_middleware)
         assert mock_add_query_strings_to_links.call_count == 0
 
@@ -52,6 +53,7 @@ class TestGlobalQueryStringsMiddleware:
         mock_add_query_strings_to_links = mocker.patch(
             "global_query_strings.middleware.add_query_strings_to_links"
         )
+        request.path = "/"
         middleware = GlobalQueryStringsMiddleware(dummy_pdf_middleware)
         assert mock_add_query_strings_to_links.call_count == 0
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -62,3 +62,31 @@ class TestGlobalQueryStringsMiddleware:
 
         # THEN
         assert mock_add_query_strings_to_links.call_count == 0
+
+    def test_exclude_admin_path_bypass_middleware(self, request, mocker):
+        # GIVEN
+        mock_add_query_strings_to_links = mocker.patch(
+            "global_query_strings.middleware.add_query_strings_to_links"
+        )
+        request.path = "/admin/dummy/"
+        middleware = GlobalQueryStringsMiddleware(dummy_html_middleware)
+
+        # WHEN
+        middleware(request)
+
+        # THEN
+        assert mock_add_query_strings_to_links.call_count == 0
+
+    def test_exclude_admin_path_do_not_bypass_middleware(self, request, mocker):
+        # GIVEN
+        mock_add_query_strings_to_links = mocker.patch(
+            "global_query_strings.middleware.add_query_strings_to_links"
+        )
+        request.path = "/dummy/"
+        middleware = GlobalQueryStringsMiddleware(dummy_html_middleware)
+
+        # WHEN
+        middleware(request)
+
+        # THEN
+        assert mock_add_query_strings_to_links.call_count == 1

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from django.urls import path
+
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+]


### PR DESCRIPTION
Two reasons why we want to do this:
1. It slows down the admin site
2. It might lead to encoding issues with `django-suit`